### PR TITLE
feat: enable manual featured projects and tag colors

### DIFF
--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -1,6 +1,8 @@
 ---
 /** Visual tag label. */
+import { TAG_COLORS, DEFAULT_TAG_COLOR } from '../data/tagColors';
 export interface Props { label: string }
 const { label } = Astro.props as Props;
+const color = TAG_COLORS[label] ?? DEFAULT_TAG_COLOR;
 ---
-<span class="text-xs border border-accent px-2 py-1 rounded">{label}</span>
+<span class={`text-xs px-2 py-1 rounded border ${color.bg} ${color.text} ${color.border}`}>{label}</span>

--- a/src/components/TagFilter.tsx
+++ b/src/components/TagFilter.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'preact/hooks';
+import { TAG_COLORS, DEFAULT_TAG_COLOR } from '../data/tagColors';
 
 /**
  * Client-side tag filter announcing changes and emitting events.
@@ -17,7 +18,7 @@ export default function TagFilter({ tags }: TagFilterProps) {
 
   const toggle = (tag: string) => {
     setSelected((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
     );
   };
 
@@ -28,17 +29,16 @@ export default function TagFilter({ tags }: TagFilterProps) {
           ? `${selected.join(', ')} filters applied`
           : 'No filters applied'}
       </p>
-      <ul class="flex flex-wrap gap-2 mb-4">
+      <ul class="mb-4 flex flex-wrap gap-2">
         {tags.map((tag) => {
           const active = selected.includes(tag);
+          const color = TAG_COLORS[tag] ?? DEFAULT_TAG_COLOR;
           return (
             <li key={tag}>
               <button
                 type="button"
                 onClick={() => toggle(tag)}
-                class={`border px-2 py-1 rounded focus-visible:outline-none ${
-                  active ? 'bg-accent text-bg' : ''
-                }`}
+                class={`rounded border px-2 py-1 focus-visible:outline-none ${color.border} ${active ? `${color.bg} ${color.text}` : color.text}`}
               >
                 {tag}
               </button>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,6 +11,7 @@ const projects = defineCollection({
     summary: z.string(),
     date: z.string(),
     tags: z.array(z.string()),
+    featured: z.boolean().optional(),
     hasPrototype: z.boolean().optional(),
     prototypeUrl: z.string().url().optional(),
     media: z.object({

--- a/src/content/projects/ax1.json
+++ b/src/content/projects/ax1.json
@@ -4,6 +4,7 @@
   "summary": "Placeholder summary for LSL Harness.",
   "date": "2025-09-05",
   "tags": ["Python", "Research"],
+  "featured": true,
   "hasPrototype": true,
   "prototypeUrl": "https://example.com/alpha",
   "media": {

--- a/src/content/projects/project-alpha.json
+++ b/src/content/projects/project-alpha.json
@@ -4,6 +4,7 @@
   "summary": "Placeholder summary for Project Alpha.",
   "date": "2024-02-01",
   "tags": ["UI", "Research"],
+  "featured": true,
   "hasPrototype": true,
   "prototypeUrl": "https://example.com/alpha",
   "media": {

--- a/src/data/tagColors.ts
+++ b/src/data/tagColors.ts
@@ -1,0 +1,35 @@
+export interface TagColor {
+  /** Background color class */
+  bg: string;
+  /** Text color class */
+  text: string;
+  /** Border color class */
+  border: string;
+}
+
+export const TAG_COLORS: Record<string, TagColor> = {
+  UX: { bg: 'bg-blue-600', text: 'text-white', border: 'border-blue-600' },
+  UI: { bg: 'bg-green-600', text: 'text-white', border: 'border-green-600' },
+  Research: {
+    bg: 'bg-purple-600',
+    text: 'text-white',
+    border: 'border-purple-600',
+  },
+  'User Research': {
+    bg: 'bg-purple-600',
+    text: 'text-white',
+    border: 'border-purple-600',
+  },
+  Python: {
+    bg: 'bg-yellow-500',
+    text: 'text-white',
+    border: 'border-yellow-500',
+  },
+  DevEx: { bg: 'bg-pink-600', text: 'text-white', border: 'border-pink-600' },
+};
+
+export const DEFAULT_TAG_COLOR: TagColor = {
+  bg: 'bg-accent',
+  text: 'text-bg',
+  border: 'border-accent',
+};

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,10 @@ import SiteFooter from '../components/SiteFooter.astro';
 import ProjectCard from '../components/ProjectCard.astro';
 import Button from '../components/Button.astro';
 import { getCollection } from 'astro:content';
-const projects = (await getCollection('projects')).sort((a,b)=> new Date(b.data.date)-new Date(a.data.date)).slice(0,4);
+const projects = (await getCollection('projects'))
+  .filter((p) => p.data.featured)
+  .sort((a, b) => new Date(b.data.date) - new Date(a.data.date))
+  .slice(0, 4);
 ---
 <BaseLayout title="Home">
   <SiteHeader />


### PR DESCRIPTION
## Summary
- allow projects to specify `featured` flag for home page selection
- support colored tags via centralized tag color map
- style Tag and TagFilter components using tag color definitions

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run format` *(fails: printer.embed has too many parameters)*

------
https://chatgpt.com/codex/tasks/task_e_68c14224d074832cb45b791f34a11457